### PR TITLE
[김민서] 나의 챌린지 페이지 - 신청한 챌린지

### DIFF
--- a/src/components/application/ApplicationDropdown.jsx
+++ b/src/components/application/ApplicationDropdown.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import styles from './AplicationDropdown.module.css';
+import styles from './ApplicationDropdown.module.css';
 import images from '../../variables/images';
 
 const AplicationDropdown = ({ onOptionChange }) => {
@@ -17,7 +17,7 @@ const AplicationDropdown = ({ onOptionChange }) => {
   };
 
   return (
-    <div className={styles.AplicationDropdown}>
+    <div className={styles.ApplicationDropdown}>
       <button className={styles['dropdown-button']} onClick={toggleDropdown}>
         <span className={styles['selected-text']}>{selectedOption}</span>
         <img

--- a/src/components/application/ApplicationDropdown.module.css
+++ b/src/components/application/ApplicationDropdown.module.css
@@ -1,7 +1,8 @@
-.AplicationDropdown {
+.ApplicationDropdown {
   position: relative;
   max-width: 150px;
   color: #737373;
+  width: 100%;
 }
 
 .dropdown-button {
@@ -58,6 +59,7 @@
   cursor: pointer;
   border-bottom: 1px solid #d4d4d4;
   padding: 10px 0;
+  width: 100%;
 }
 
 .dropdown-item:last-child {
@@ -75,8 +77,9 @@
   }
 
   .dropdown-list {
-    min-width: 139px;
+    max-width: 139px;
     min-height: 270px;
+    width: 100%;
   }
 
   .dropdown-item {

--- a/src/components/application/ChallengeSearchbar.module.css
+++ b/src/components/application/ChallengeSearchbar.module.css
@@ -5,10 +5,14 @@
   border: 1px solid #e5e5e5;
   border-radius: 20px;
   height: 40px;
+  padding: 0 10px;
+  flex-grow: 1;
+  max-width: 100%;
+  min-width: 225px;
 }
 
 .icon {
-  margin-left: 4px;
+  margin-right: 10px;
 }
 
 .input {
@@ -26,11 +30,9 @@
   color: #a3a3a3;
 }
 
-/* 데스크탑 버전 */
 @media (min-width: 1200px) {
   .ChallengeSearchbar {
     max-width: 744px;
-    width: 100%;
   }
 
   .input {
@@ -39,7 +41,6 @@
   }
 }
 
-/* 태블릿 버전 */
 @media (min-width: 744px) and (max-width: 1199px) {
   .ChallengeSearchbar {
     max-width: 545px;
@@ -51,10 +52,9 @@
   }
 }
 
-/* 모바일 버전 */
 @media (max-width: 743px) {
   .ChallengeSearchbar {
-    max-width: 225px;
+    max-width: 100%;
   }
 
   .input {
@@ -62,4 +62,3 @@
     line-height: 16.71px;
   }
 }
-

--- a/src/components/application/ChallengeTable.jsx
+++ b/src/components/application/ChallengeTable.jsx
@@ -20,10 +20,25 @@ const getStatusLabel = (status) => {
 // 날짜를 'YY/MM/DD' 형식으로 변환하는 함수
 const formatDate = (dateString) => {
   const date = new Date(dateString);
-  const year = date.getFullYear().toString().slice(2); // 연도 마지막 두 자리
-  const month = (date.getMonth() + 1).toString().padStart(2, '0'); // 월 (1부터 시작)
-  const day = date.getDate().toString().padStart(2, '0'); // 일
+  const year = date.getFullYear().toString().slice(2);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
   return `${year}/${month}/${day}`;
+};
+
+const getStatusClass = (status) => {
+  switch (status) {
+    case 'WAITING':
+      return styles.waiting;
+    case 'ACCEPTED':
+      return styles.accepted;
+    case 'REJECTED':
+      return styles.rejected;
+    case 'DELETED':
+      return styles.deleted;
+    default:
+      return '';
+  }
 };
 
 const ChallengeTable = ({ data }) => {
@@ -41,7 +56,10 @@ const ChallengeTable = ({ data }) => {
       </div>
 
       {data.map((item) => (
-        <div key={item.id} className={styles.row}>
+        <div
+          key={item.id}
+          className={`${styles.row} ${item.status === 'DELETED' ? styles.deletedRow : ''}`}
+        >
           <div className={styles.no}>{item.id}</div>
           <div className={styles.field}>{item.docType === 'OFFICIAL' ? '공식문서' : '블로그'}</div>
           <div className={styles.category}>{item.field}</div>
@@ -49,7 +67,9 @@ const ChallengeTable = ({ data }) => {
           <div className={styles.participants}>{item.participates}</div>
           <div className={styles.applicationDate}>{formatDate(item.applicationDate)}</div>
           <div className={styles.deadline}>{formatDate(item.deadline)}</div>
-          <div className={styles.status}>{getStatusLabel(item.status)}</div>
+          <div className={`${styles.status} ${getStatusClass(item.status)}`}>
+            {getStatusLabel(item.status)}
+          </div>
         </div>
       ))}
     </div>

--- a/src/components/application/ChallengeTable.module.css
+++ b/src/components/application/ChallengeTable.module.css
@@ -7,6 +7,7 @@
   display: flex;
   width: 100%;
   max-width: 996px;
+  box-sizing: border-box;
 }
 
 /* 데스크탑 버전 */
@@ -15,7 +16,7 @@
   .row {
     max-width: 996px;
     height: 36px;
-    border-radius: 8px;
+    box-sizing: border-box;
   }
 
   .header {
@@ -28,6 +29,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    border-radius: 8px;
   }
 
   .no,
@@ -51,7 +53,12 @@
   }
 
   .title {
-    flex: 2;
+    flex: 3;
+    justify-content: start;
+  }
+
+  .field, .category {
+    justify-content: start;
   }
 
   .row {
@@ -78,6 +85,7 @@
   .row {
     max-width: 696px;
     height: 36px;
+    box-sizing: border-box;
   }
 
   .header {
@@ -113,7 +121,12 @@
   }
 
   .title {
-    flex: 2;
+    flex: 3;
+    justify-content: start;
+  }
+
+  .field, .category {
+    justify-content: start;
   }
 
   .row {
@@ -140,7 +153,7 @@
 }
 
 /* 모바일 버전 */
-@media (max-width: 743px) {
+@media (max-width: 743px) and (min-width: 375px) {
   .tableContainer {
     overflow-x: auto;
   }
@@ -148,8 +161,10 @@
   .header,
   .row {
     min-width: 696px;
+    width: 100%;
     height: auto;
     flex-direction: row;
+    box-sizing: border-box;
   }
 
   .header {
@@ -168,5 +183,41 @@
     font-weight: 400;
     font-size: 12px;
   }
+}
+
+.status {
+  max-width: 70px;
+  max-height: 24px;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.waiting {
+  background-color: #FFFDE7;
+  color: #F2BC00;
+}
+
+.accepted {
+  background-color: #DFF0FF;
+  color: #4095DE;
+}
+
+.rejected {
+  background-color: #FFF0F0;
+  color: #E54946;
+}
+
+.deleted {
+  background-color: #E5E5E5;
+  color: #737373;
+}
+
+.deletedRow {
+  background-color: #F5F5F5 !important;
 }
 

--- a/src/components/application/SearchbarWithDropdown.jsx
+++ b/src/components/application/SearchbarWithDropdown.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import ChallengeSearchbar from './ChallengeSearchbar';
-import AplicationDropdown from './AplicationDropdown';
+import ApplicationDropdown from './ApplicationDropdown';
 import styles from './SearchbarWithDropdown.module.css';
 
 const SearchbarWithDropdown = ({ searchTerm, setSearchTerm, onOptionChange }) => {
   return (
     <div className={styles.SearchbarWithDropdown}>
       <ChallengeSearchbar searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
-      <AplicationDropdown onOptionChange={onOptionChange} />
+      <ApplicationDropdown onOptionChange={onOptionChange} />
     </div>
   );
 };

--- a/src/components/application/SearchbarWithDropdown.module.css
+++ b/src/components/application/SearchbarWithDropdown.module.css
@@ -1,24 +1,43 @@
+.SearchbarWithDropdown,
+.SearchbarWithDropdown > * {
+  box-sizing: border-box;
+}
+
+
 .SearchbarWithDropdown {
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
   max-width: 996px;
-  margin: 0 auto;
+  margin: 0;
+  width: 100%;
 }
 
 .SearchbarWithDropdown > * {
   flex-shrink: 0;
-  margin-right: 10px;
+  margin-right: 5px;
+  box-sizing: border-box;
 }
 
 .SearchbarWithDropdown > *:last-child {
   margin-right: 0;
 }
 
+@media (max-width: 1199px) {
+  .SearchbarWithDropdown {
+    max-width: 697px;
+    width: 100%;
+    margin: 0;
+    box-sizing: border-box;
+  }
+}
+
 @media (max-width: 743px) {
   .SearchbarWithDropdown {
-    max-width: 343px;
+    min-width: 343px;
+    width: 100%;
+    margin: 0;
   }
 
   .SearchbarWithDropdown > * {

--- a/src/components/layouts/Layout.module.css
+++ b/src/components/layouts/Layout.module.css
@@ -1,18 +1,24 @@
 .main {
-  max-width: 1200px;
+  max-width: 996px;
   width: 100%;
   padding-top: 24px;
   padding-bottom: 150px;
   margin: 0 auto;
 }
+
 @media only screen and (max-width: 1199px) {
   .main {
-    padding: 24px 24px 40px;
+    max-width: 696px;
+    width: 100%;
+    padding: auto;
   }
 }
 
-@media only screen and (max-width: 743px) {
+@media only screen and (max-width: 743px) and (min-width: 375px) {
   .main {
-    padding: 16px 16px 32px;
+    min-width: 343px;
+    width: 100%;
+    padding: 20px;
   }
 }
+

--- a/src/pages/me/application/index.jsx
+++ b/src/pages/me/application/index.jsx
@@ -20,9 +20,7 @@ export default function MyApplicationPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
-  const totalPages = 5;
 
-  // 시드 데이터
   const seedData = [
     {
       id: 1023,
@@ -181,6 +179,9 @@ export default function MyApplicationPage() {
       return 0;
     });
 
+  // 페이지 수 계산
+  const totalPages = Math.ceil(filteredData.length / itemsPerPage);
+
   // 현재 페이지의 데이터만 추출
   const paginatedData = filteredData.slice(
     (currentPage - 1) * itemsPerPage,
@@ -197,7 +198,6 @@ export default function MyApplicationPage() {
         />
       </Head>
       <div className={styles.pageContainer}>
-        <h1>신청한 챌린지 내용</h1>
         <div className={styles.tabNavigationWrapper}>
           <TabNavigation activeTab="applications" />
         </div>
@@ -220,7 +220,7 @@ export default function MyApplicationPage() {
         <div className={styles.paginationWrapper}>
           <Pagination
             currentPage={currentPage}
-            totalPages={totalPages}
+            totalPages={totalPages} // 계산된 totalPages 사용
             onPageChange={handlePageChange}
           />
         </div>
@@ -228,3 +228,4 @@ export default function MyApplicationPage() {
     </>
   );
 }
+

--- a/src/styles/pages/application/MyApplicationPage.module.css
+++ b/src/styles/pages/application/MyApplicationPage.module.css
@@ -1,39 +1,33 @@
 .pageContainer {
   width: 100%;
-  padding: 20px;
   box-sizing: border-box;
 }
 
-.application-search-dropdown-container {
+.applicationSearchDropdownContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  max-width: 996px;
   margin-bottom: 20px;
   margin-top: 20px;
   box-sizing: border-box;
   flex-wrap: nowrap;
 }
 
-.tabNavigationWrapper {
-  margin-bottom: 20px;
-}
-
-.application-search-dropdown-container > * {
+.applicationSearchDropdownContainer > * {
   margin-right: 10px;
 }
 
-.application-search-dropdown-container > *:last-child {
+.applicationSearchDropdownContainer > *:last-child {
   margin-right: 0;
 }
 
-.challenge-table-wrapper {
+.challengeTableWrapper {
   width: 100%;
-  max-width: 996px;
   overflow-x: auto;
   padding-bottom: 20px;
   box-sizing: border-box;
+  margin-top: 20px;
 }
 
 .noChallengesMessage {
@@ -48,20 +42,16 @@
 
 /* 태블릿 버전 */
 @media (max-width: 1199px) {
-  .application-search-dropdown-container {
+  .applicationSearchDropdownContainer {
     max-width: 100%;
   }
 }
 
 /* 모바일 버전 */
 @media (max-width: 743px) {
-  .application-search-dropdown-container {
+  .applicationSearchDropdownContainer {
     flex-direction: column;
     align-items: stretch;
-  }
-
-  .application-search-dropdown-container > * {
-    margin-bottom: 10px;
   }
 
   .noChallengesMessage {
@@ -69,9 +59,11 @@
   }
 }
 
-.pagination-wrapper {
+.paginationWrapper {
   display: flex;
   justify-content: center;
+  align-items: center;
   margin-top: 40px !important;
+  width: 100%;
 }
 


### PR DESCRIPTION
#### 추가사항

- [x] 나의 챌린지 페이지에서 데이터 기반으로 페이지 수 동적 계산 기능 추가
- [x] 나의 챌린지 페이지 신청한 챌린지 섹션 데스크탑, 태블릿, 모바일 반응형 구현
- [x] 챌린지 삭제 상태에 대한 CSS 스타일 추가
- [x] Layout에 반응형에 따른 가운데 배치 추가

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ] 나의 챌린지 페이지에서 신청한 챌린지의 승인 상태 상세 페이지

#### 테스트 완료 여부

- [x] 테스트 완료

#### 스크린샷
##### **데스크탑**
![image](https://github.com/user-attachments/assets/832d4ee8-3edc-4fe4-887b-8411601abbfc)

##### **태블릿**
![image](https://github.com/user-attachments/assets/75671899-e81c-48d6-979c-c06e03d23981)

##### **모바일**
![image](https://github.com/user-attachments/assets/204af459-1171-4e48-b29f-98e49753977a)


#### 코멘트

