### PR TITLE
[김민서] 신규 챌린지 신청 페이지 - 추가 적용 및 수정

### DIFF
--- a/public/assets/icons/ic_up.svg
+++ b/public/assets/icons/ic_up.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="9" viewBox="0 0 16 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1.25 8.75L8 2.25L14.75 8.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/application/DocTypeSelection.jsx
+++ b/src/components/application/DocTypeSelection.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styles from './DocTypeSelection.module.css';
+
+const DocTypeSelection = ({ onOptionChange }) => {
+  const options = ['공식 문서', '블로그'];
+
+  return (
+    <ul className={styles['dropdown-list']}>
+      {options.map((option, index) => (
+        <li
+          key={index}
+          className={styles['dropdown-item']}
+          onClick={() => onOptionChange(option)}
+        >
+          {option}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default DocTypeSelection;
+

--- a/src/components/application/DocTypeSelection.module.css
+++ b/src/components/application/DocTypeSelection.module.css
@@ -1,0 +1,49 @@
+.dropdown-list {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  background-color: #ffffff;
+  border: 1px solid var(--grey-300);
+  border-radius: 8px;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.dropdown-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 43px;
+  font-size: 16px;
+  color: var(--grey-500);
+  border-bottom: 1px solid var(--grey-300);
+  padding: 0 10px;
+  cursor: pointer;
+}
+
+.dropdown-item:first-child {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.dropdown-item:last-child {
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  border-bottom: none;
+}
+
+.dropdown-item:hover {
+  background-color: #f1f1f1;
+}
+
+.dropdown-item:first-child:hover {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.dropdown-item:last-child:hover {
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+

--- a/src/components/application/FieldSelection.jsx
+++ b/src/components/application/FieldSelection.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styles from './FieldSelection.module.css';
+
+const FieldSelection = ({ onOptionChange }) => {
+  const options = ['Next.js', 'API', 'Career', 'Modern JS', 'Web'];
+
+  return (
+    <ul className={styles['dropdown-list']}>
+      {options.map((option, index) => (
+        <li
+          key={index}
+          className={styles['dropdown-item']}
+          onClick={() => onOptionChange(option)}
+        >
+          {option}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default FieldSelection;
+

--- a/src/components/application/FieldSelection.module.css
+++ b/src/components/application/FieldSelection.module.css
@@ -1,0 +1,49 @@
+.dropdown-list {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  background-color: #ffffff;
+  border: 1px solid var(--grey-300);
+  border-radius: 8px;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.dropdown-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 43px;
+  font-size: 16px;
+  color: var(--grey-500);
+  border-bottom: 1px solid var(--grey-300);
+  padding: 0 10px;
+  cursor: pointer;
+}
+
+.dropdown-item:first-child {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.dropdown-item:last-child {
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  border-bottom: none;
+}
+
+.dropdown-item:hover {
+  background-color: #f1f1f1;
+}
+
+.dropdown-item:first-child:hover {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.dropdown-item:last-child:hover {
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+

--- a/src/pages/application/[id].jsx
+++ b/src/pages/application/[id].jsx
@@ -1,111 +1,299 @@
-import React, { useState } from 'react';
-import Head from 'next/head';
-import styles from '../../styles/pages/application/EditApplicationPage.module.css';
+import React, { useState } from "react";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import styles from "../../styles/pages/application/EditApplicationPage.module.css";
+import { createChallengeApplication } from "../../service/api/challenge";
+import Loader from "../../components/common/Loader";
+import FieldSelection from "../../components/application/FieldSelection";
+import DocTypeSelection from "../../components/application/DocTypeSelection";
+import assets from "../../variables/images";
 
-export default function EditApplicationPage() {
-  const [selectedDate, setSelectedDate] = useState('');
+const fieldMapping = {
+  "Next.js": "NEXTJS",
+  API: "API",
+  Career: "CAREER",
+  "Modern JS": "MODERNJS",
+  Web: "WEB",
+};
 
-  // 날짜 변경
+const docTypeMapping = {
+  "공식 문서": "OFFICIAL",
+  블로그: "BLOG",
+};
+
+const EditApplicationPage = () => {
+  const [formData, setFormData] = useState({
+    title: "",
+    docUrl: "",
+    field: "",
+    docType: "",
+    deadline: "",
+    maxParticipants: "",
+    description: "",
+  });
+
+  const [selectedDate, setSelectedDate] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [fieldDropdownOpen, setFieldDropdownOpen] = useState(false);
+  const [docTypeDropdownOpen, setDocTypeDropdownOpen] = useState(false);
+  const router = useRouter();
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }));
+  };
+
+  const handleFieldSelect = (value) => {
+    setFormData((prevData) => ({
+      ...prevData,
+      field: value,
+    }));
+    setFieldDropdownOpen(false);
+  };
+
+  const handleDocTypeSelect = (value) => {
+    setFormData((prevData) => ({
+      ...prevData,
+      docType: value,
+    }));
+    setDocTypeDropdownOpen(false);
+  };
+
   const handleDateChange = (e) => {
     const date = e.target.value;
-    const formattedDate = new Date(date).toISOString().slice(0, 10).replace(/-/g, '/');
-    setSelectedDate(formattedDate);
+    setSelectedDate(date);
+    setFormData((prevData) => ({
+      ...prevData,
+      deadline: new Date(date).toISOString(),
+    }));
+  };
+
+  const validateForm = () => {
+    const {
+      title,
+      docUrl,
+      field,
+      docType,
+      deadline,
+      maxParticipants,
+      description,
+    } = formData;
+    if (
+      !title ||
+      !docUrl ||
+      !field ||
+      !docType ||
+      !deadline ||
+      !maxParticipants ||
+      !description
+    ) {
+      return "모든 필드를 입력해주세요.";
+    }
+    return null;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const errorMsg = validateForm();
+    if (errorMsg) {
+      setError(errorMsg);
+      setLoading(false);
+      return;
+    }
+
+    const dataToSend = {
+      title: formData.title,
+      docUrl: formData.docUrl,
+      field: fieldMapping[formData.field],
+      docType: docTypeMapping[formData.docType],
+      deadline: formData.deadline,
+      maxParticipants: Number(formData.maxParticipants),
+      description: formData.description,
+    };
+
+    try {
+      await createChallengeApplication(dataToSend);
+      alert("챌린지 수정이 성공적으로 완료되었습니다!");
+      router.push("/me/application");
+    } catch (error) {
+      setError("챌린지 수정 중 오류가 발생했습니다. 다시 시도해주세요.");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <>
       <Head>
         <title>챌린지 수정하기</title>
-        <meta name="description" content="챌린지를 수정하는 페이지입니다." />
+        <meta
+          name="description"
+          content="사용자가 챌린지를 수정하는 페이지입니다."
+        />
       </Head>
       <div className={styles.EditApplicationPage}>
-        <h1 className={styles['application-title']}>챌린지 수정하기</h1>
-        <form className={styles.form}>
-          <label className={styles.label}>제목</label>
-          <div className={styles['input-wrapper']}>
-            <input
-              type="text"
-              name="applicationTitle"
-              placeholder="제목을 입력해주세요"
-              className={styles.input}
-            />
-          </div>
+        <h1 className={styles["application-title"]}>챌린지 수정하기</h1>
+        {loading && <Loader msg="챌린지를 수정 중입니다" />}
+        {!loading && (
+          <form className={styles.form} onSubmit={handleSubmit}>
+            <label className={styles.label}>제목</label>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "12px" }}
+            >
+              <input
+                type="text"
+                name="title"
+                placeholder="제목을 입력해주세요"
+                className={styles.input}
+                value={formData.title}
+                onChange={handleInputChange}
+              />
+            </div>
 
-          <label className={styles.label}>원문 링크</label>
-          <div className={styles['input-wrapper']}>
-            <input
-              type="text"
-              name="docUrl"
-              placeholder="원문 링크를 입력해주세요"
-              className={styles.input}
-            />
-          </div>
+            <label className={styles.label}>원문 링크</label>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "12px" }}
+            >
+              <input
+                type="text"
+                name="docUrl"
+                placeholder="원문 링크를 입력해주세요"
+                className={styles.input}
+                value={formData.docUrl}
+                onChange={handleInputChange}
+              />
+            </div>
 
-          <label className={styles.label}>분야</label>
-          <div className={styles['input-wrapper']}>
-            <input
-              type="text"
-              name="field"
-              placeholder="카테고리"
-              className={styles['select-input']}
-            />
-            <img src="/assets/icons/ic_down.svg" className={styles.icon} />
-          </div>
+            <label className={styles.label}>분야</label>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "4px" }}
+            >
+              <input
+                type="text"
+                name="field"
+                placeholder="분야를 선택해주세요"
+                className={styles["select-input"]}
+                value={formData.field}
+                readOnly
+              />
+              <img
+                src={fieldDropdownOpen ? assets.icons.up : assets.icons.down}
+                className={styles.icon}
+                onClick={() => setFieldDropdownOpen(!fieldDropdownOpen)}
+              />
+              {fieldDropdownOpen && (
+                <div className={styles.dropdownContainer}>
+                  <FieldSelection onOptionChange={handleFieldSelect} />
+                </div>
+              )}
+            </div>
 
-          <label className={styles.label}>문서타입</label>
-          <div className={styles['input-wrapper']}>
-            <input
-              type="text"
-              name="docType"
-              placeholder="카테고리"
-              className={styles['select-input']}
-            />
-            <img src="/assets/icons/ic_down.svg" className={styles.icon} />
-          </div>
+            <label className={styles.label}>문서 타입</label>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "4px" }}
+            >
+              <input
+                type="text"
+                name="docType"
+                placeholder="문서타입을 선택해주세요"
+                className={styles["select-input"]}
+                value={formData.docType}
+                readOnly
+              />
+              <img
+                src={docTypeDropdownOpen ? assets.icons.up : assets.icons.down}
+                className={styles.icon}
+                onClick={() => setDocTypeDropdownOpen(!docTypeDropdownOpen)}
+              />
+              {docTypeDropdownOpen && (
+                <div className={styles.dropdownContainer}>
+                  <DocTypeSelection onOptionChange={handleDocTypeSelect} />
+                </div>
+              )}
+            </div>
 
-          <label className={styles.label}>마감일</label>
-          <div className={styles['input-wrapper']}>
-            <input
-              type="text"
-              name="deadline"
-              placeholder="YYYY/MM/DD"
-              className={styles.input}
-              value={selectedDate}
-              readOnly
-            />
-            <input
-              type="date"
-              className={styles.dateInput}
-              onChange={handleDateChange}
-            />
-            <img
-              src="/assets/icons/ic_calender.svg"
-              className={styles.icon}
-              onClick={() => document.querySelector(`.${styles.dateInput}`).showPicker()} // 클릭 시 달력 열기
-            />
-          </div>
+            <label className={styles.label}>마감일</label>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "12px" }}
+            >
+              <input
+                type="text"
+                name="deadline"
+                placeholder="YYYY-MM-DD"
+                className={styles.input}
+                value={selectedDate}
+                readOnly
+              />
+              <input
+                type="date"
+                className={styles.dateInput}
+                onChange={handleDateChange}
+              />
+              <img
+                src={assets.icons.calender}
+                className={styles.icon}
+                onClick={() =>
+                  document.querySelector(`.${styles.dateInput}`).showPicker()
+                }
+              />
+            </div>
 
-          <label className={styles.label}>최대인원</label>
-          <div className={styles['input-wrapper']}>
-            <input
-              type="text"
-              name="maxParticipants"
-              placeholder="인원을 입력해주세요"
-              className={styles.input}
-            />
-          </div>
+            <label className={styles.label}>최대 인원</label>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "12px" }}
+            >
+              <input
+                type="text"
+                name="maxParticipants"
+                placeholder="인원을 입력해주세요"
+                className={styles.input}
+                value={formData.maxParticipants}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (/^\d*$/.test(value)) {
+                    handleInputChange(e);
+                  }
+                }}
+              />
+            </div>
 
-          <label className={styles.label}>내용</label>
-          <textarea
-            name="description"
-            placeholder="내용을 입력해주세요"
-            className={styles.textarea}
-          ></textarea>
+            <label className={styles.label}>내용</label>
+            <textarea
+              name="description"
+              placeholder="내용을 입력해주세요"
+              className={styles.textarea}
+              value={formData.description}
+              onChange={handleInputChange}
+              style={{ borderRadius: "12px" }}
+            ></textarea>
 
-          <button className={styles['submit-button']}>수정하기</button>
-        </form>
+            <button
+              className={styles["submit-button"]}
+              type="submit"
+              style={{ borderRadius: "8px" }}
+            >
+              수정하기
+            </button>
+          </form>
+        )}
+
+        {error && <p className={styles.error}>{error}</p>}
       </div>
     </>
   );
-}
+};
 
+export default EditApplicationPage;

--- a/src/pages/application/index.jsx
+++ b/src/pages/application/index.jsx
@@ -4,8 +4,24 @@ import { useRouter } from "next/router";
 import styles from "../../styles/pages/application/CreateApplicationPage.module.css";
 import { createChallengeApplication } from "../../service/api/challenge";
 import Loader from "../../components/common/Loader";
+import FieldSelection from "../../components/application/FieldSelection";
+import DocTypeSelection from "../../components/application/DocTypeSelection";
+import assets from "../../variables/images";
 
-export default function CreateApplicationPage() {
+const fieldMapping = {
+  "Next.js": "NEXTJS",
+  API: "API",
+  Career: "CAREER",
+  "Modern JS": "MODERNJS",
+  Web: "WEB",
+};
+
+const docTypeMapping = {
+  "공식 문서": "OFFICIAL",
+  블로그: "BLOG",
+};
+
+const CreateApplicationPage = () => {
   const [formData, setFormData] = useState({
     title: "",
     docUrl: "",
@@ -16,9 +32,11 @@ export default function CreateApplicationPage() {
     description: "",
   });
 
-  const [selectedDate, setSelectedDate] = useState(""); // 화면에서만 표시 될 날짜
+  const [selectedDate, setSelectedDate] = useState(""); // 화면에서만 표시될 날짜
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [fieldDropdownOpen, setFieldDropdownOpen] = useState(false);
+  const [docTypeDropdownOpen, setDocTypeDropdownOpen] = useState(false);
   const router = useRouter();
 
   const handleInputChange = (e) => {
@@ -29,22 +47,32 @@ export default function CreateApplicationPage() {
     }));
   };
 
-  // 날짜 변경
-  const handleDateChange = (e) => {
-    const date = e.target.value;
-    const formattedDate = new Date(date).toISOString();
-    setSelectedDate(date); // 선택한 날짜를 업데이트 (YYYY-MM-DD)
+  const handleFieldSelect = (value) => {
     setFormData((prevData) => ({
       ...prevData,
-      deadline: formattedDate, // ISO 형식으로 폼 데이터 업데이트
+      field: value, // UI상으로는 선택한 값 유지
+    }));
+    setFieldDropdownOpen(false);
+  };
+
+  const handleDocTypeSelect = (value) => {
+    setFormData((prevData) => ({
+      ...prevData,
+      docType: value, // UI상으로는 선택한 값 유지
+    }));
+    setDocTypeDropdownOpen(false);
+  };
+
+  const handleDateChange = (e) => {
+    const date = e.target.value;
+    setSelectedDate(date);
+    setFormData((prevData) => ({
+      ...prevData,
+      deadline: new Date(date).toISOString(), // ISO 형식으로 변환하여 저장
     }));
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setLoading(true);
-    setError(null);
-
+  const validateForm = () => {
     const {
       title,
       docUrl,
@@ -63,33 +91,38 @@ export default function CreateApplicationPage() {
       !maxParticipants ||
       !description
     ) {
-      setError("모든 필드를 입력해주세요.");
+      return "모든 필드를 입력해주세요.";
+    }
+    return null;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const errorMsg = validateForm();
+    if (errorMsg) {
+      setError(errorMsg);
       setLoading(false);
       return;
     }
 
     const dataToSend = {
-      title,
-      docUrl,
-      field,
-      docType,
-      deadline,
-      maxParticipants: Number(maxParticipants),
-      description,
+      title: formData.title,
+      docUrl: formData.docUrl,
+      field: fieldMapping[formData.field],
+      docType: docTypeMapping[formData.docType],
+      deadline: formData.deadline,
+      maxParticipants: Number(formData.maxParticipants),
+      description: formData.description,
     };
 
-    console.log("전송할 데이터:", JSON.stringify(dataToSend, null, 2));
-
     try {
-      const response = await createChallengeApplication(dataToSend);
-      console.log("챌린지 생성 성공:", response);
+      await createChallengeApplication(dataToSend);
       alert("챌린지 신청이 성공적으로 완료되었습니다!");
       router.push("/me/application");
     } catch (error) {
-      console.error(
-        "챌린지 생성 실패:",
-        error.response ? error.response.data : error.message
-      );
       setError("챌린지 생성 중 오류가 발생했습니다. 다시 시도해주세요.");
     } finally {
       setLoading(false);
@@ -107,13 +140,14 @@ export default function CreateApplicationPage() {
       </Head>
       <div className={styles.CreateApplicationPage}>
         <h1 className={styles["application-title"]}>신규 챌린지 신청</h1>
-
         {loading && <Loader msg="챌린지를 생성 중입니다" />}
-
         {!loading && (
           <form className={styles.form} onSubmit={handleSubmit}>
             <label className={styles.label}>제목</label>
-            <div className={styles["input-wrapper"]}>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "12px" }}
+            >
               <input
                 type="text"
                 name="title"
@@ -125,7 +159,10 @@ export default function CreateApplicationPage() {
             </div>
 
             <label className={styles.label}>원문 링크</label>
-            <div className={styles["input-wrapper"]}>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "12px" }}
+            >
               <input
                 type="text"
                 name="docUrl"
@@ -137,39 +174,66 @@ export default function CreateApplicationPage() {
             </div>
 
             <label className={styles.label}>분야</label>
-            <div className={styles["input-wrapper"]}>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "4px" }}
+            >
               <input
                 type="text"
                 name="field"
-                placeholder="분야를 입력해주세요"
+                placeholder="분야를 선택해주세요"
                 className={styles["select-input"]}
                 value={formData.field}
-                onChange={handleInputChange}
+                readOnly
               />
-              <img src="/assets/icons/ic_down.svg" className={styles.icon} />
+              <img
+                src={fieldDropdownOpen ? assets.icons.up : assets.icons.down}
+                className={styles.icon}
+                onClick={() => setFieldDropdownOpen(!fieldDropdownOpen)}
+              />
+              {fieldDropdownOpen && (
+                <div className={styles.dropdownContainer}>
+                  <FieldSelection onOptionChange={handleFieldSelect} />
+                </div>
+              )}
             </div>
 
             <label className={styles.label}>문서타입</label>
-            <div className={styles["input-wrapper"]}>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "4px" }}
+            >
               <input
                 type="text"
                 name="docType"
-                placeholder="문서타입을 입력해주세요"
+                placeholder="문서타입을 선택해주세요"
                 className={styles["select-input"]}
                 value={formData.docType}
-                onChange={handleInputChange}
+                readOnly
               />
-              <img src="/assets/icons/ic_down.svg" className={styles.icon} />
+              <img
+                src={docTypeDropdownOpen ? assets.icons.up : assets.icons.down}
+                className={styles.icon}
+                onClick={() => setDocTypeDropdownOpen(!docTypeDropdownOpen)}
+              />
+              {docTypeDropdownOpen && (
+                <div className={styles.dropdownContainer}>
+                  <DocTypeSelection onOptionChange={handleDocTypeSelect} />
+                </div>
+              )}
             </div>
 
             <label className={styles.label}>마감일</label>
-            <div className={styles["input-wrapper"]}>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "12px" }}
+            >
               <input
                 type="text"
                 name="deadline"
                 placeholder="YYYY-MM-DD"
                 className={styles.input}
-                value={selectedDate} // 화면에 표시할 날짜
+                value={selectedDate}
                 readOnly
               />
               <input
@@ -178,7 +242,7 @@ export default function CreateApplicationPage() {
                 onChange={handleDateChange}
               />
               <img
-                src="/assets/icons/ic_calender.svg"
+                src={assets.icons.calender}
                 className={styles.icon}
                 onClick={() =>
                   document.querySelector(`.${styles.dateInput}`).showPicker()
@@ -187,14 +251,22 @@ export default function CreateApplicationPage() {
             </div>
 
             <label className={styles.label}>최대인원</label>
-            <div className={styles["input-wrapper"]}>
+            <div
+              className={styles["input-wrapper"]}
+              style={{ borderRadius: "12px" }}
+            >
               <input
-                type="number"
+                type="text"
                 name="maxParticipants"
                 placeholder="인원을 입력해주세요"
                 className={styles.input}
                 value={formData.maxParticipants}
-                onChange={handleInputChange}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (/^\d*$/.test(value)) {
+                    handleInputChange(e); // 숫자만 허용
+                  }
+                }}
               />
             </div>
 
@@ -205,6 +277,7 @@ export default function CreateApplicationPage() {
               className={styles.textarea}
               value={formData.description}
               onChange={handleInputChange}
+              style={{ borderRadius: "6px" }}
             ></textarea>
 
             <button className={styles["submit-button"]} type="submit">
@@ -217,5 +290,7 @@ export default function CreateApplicationPage() {
       </div>
     </>
   );
-}
+};
+
+export default CreateApplicationPage;
 

--- a/src/pages/application/index.jsx
+++ b/src/pages/application/index.jsx
@@ -198,7 +198,7 @@ const CreateApplicationPage = () => {
               )}
             </div>
 
-            <label className={styles.label}>문서타입</label>
+            <label className={styles.label}>문서 타입</label>
             <div
               className={styles["input-wrapper"]}
               style={{ borderRadius: "4px" }}
@@ -250,7 +250,7 @@ const CreateApplicationPage = () => {
               />
             </div>
 
-            <label className={styles.label}>최대인원</label>
+            <label className={styles.label}>최대 인원</label>
             <div
               className={styles["input-wrapper"]}
               style={{ borderRadius: "12px" }}
@@ -277,10 +277,14 @@ const CreateApplicationPage = () => {
               className={styles.textarea}
               value={formData.description}
               onChange={handleInputChange}
-              style={{ borderRadius: "6px" }}
+              style={{ borderRadius: "12px" }}
             ></textarea>
 
-            <button className={styles["submit-button"]} type="submit">
+            <button
+              className={styles["submit-button"]}
+              type="submit"
+              style={{ borderRadius: "8px" }}
+            >
               신청하기
             </button>
           </form>
@@ -293,4 +297,3 @@ const CreateApplicationPage = () => {
 };
 
 export default CreateApplicationPage;
-

--- a/src/styles/pages/application/CreateApplicationPage.module.css
+++ b/src/styles/pages/application/CreateApplicationPage.module.css
@@ -19,7 +19,7 @@
 .label {
   font-size: 14px;
   font-weight: 500;
-  color: #171717;
+  color: var(--grey-900);
   margin-bottom: 10px;
 }
 
@@ -27,8 +27,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  border: 1px solid #e5e5e5;
-  border-radius: 12px;
+  border: 1px solid var(--grey-200);
   margin-bottom: 30px;
 }
 
@@ -38,7 +37,7 @@
   height: 48px;
   border: none;
   font-size: 16px;
-  color: #171717;
+  color: var(--grey-900);
   box-sizing: border-box;
   padding-left: 20px;
   padding-right: 50px;
@@ -47,7 +46,13 @@
 .input::placeholder,
 .select-input::placeholder {
   font-weight: 400;
-  color: #a3a3a3;
+  color: var(--grey-400);
+}
+
+.input:focus,
+.select-input:focus,
+.textarea:focus {
+  outline: none;
 }
 
 .icon {
@@ -58,28 +63,77 @@
   width: 20px;
   height: 20px;
   cursor: pointer;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.dropdownContainer {
+  position: absolute;
+  top: calc(100% + 8px);
+  width: 100%;
+  z-index: 1000;
+  background-color: #ffffff;
+
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.dropdown-list {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  background-color: #ffffff;
+  border: 1px solid var(--grey-300);
+
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.dropdown-item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 43px;
+  font-size: 16px;
+  color: #737373;
+  border-bottom: 1px solid var(--grey-300);
+  padding: 0 10px;
+  cursor: pointer;
+}
+
+.dropdown-item:first-child {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.dropdown-item:last-child {
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  border-bottom: none;
+}
+
+.dropdown-item:hover {
+  background-color: #f1f1f1;
 }
 
 .textarea {
   width: 100%;
   height: 219px;
-  border: 1px solid #e5e5e5;
-  border-radius: 6px;
+  border: 1px solid var(--grey-200);
+
   padding: 16px 20px;
   margin-bottom: 30px;
   font-size: 16px;
-  color: #171717;
+  color: var(--grey-900);
 }
 
 .textarea::placeholder {
   font-weight: 400;
-  color: #a3a3a3;
+  color: var(--grey-400);
 }
 
 .submit-button {
   width: 100%;
   height: 48px;
-  background-color: #262626;
+  background-color: var(--grey-800);
   color: #ffffff;
   font-size: 16px;
   font-weight: 600;
@@ -93,6 +147,12 @@
   position: absolute;
   opacity: 0;
   pointer-events: none;
+}
+
+.error {
+  color: red;
+  font-size: 14px;
+  margin-top: 10px;
 }
 
 @media (max-width: 1199px) {

--- a/src/styles/pages/application/EditApplicationPage.module.css
+++ b/src/styles/pages/application/EditApplicationPage.module.css
@@ -19,7 +19,7 @@
 .label {
   font-size: 14px;
   font-weight: 500;
-  color: #171717;
+  color: var(--grey-900);
   margin-bottom: 10px;
 }
 
@@ -27,8 +27,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  border: 1px solid #e5e5e5;
-  border-radius: 12px;
+  border: 1px solid var(--grey-200);
   margin-bottom: 30px;
 }
 
@@ -38,7 +37,7 @@
   height: 48px;
   border: none;
   font-size: 16px;
-  color: #171717;
+  color: var(--grey-900);
   box-sizing: border-box;
   padding-left: 20px;
   padding-right: 50px;
@@ -47,7 +46,13 @@
 .input::placeholder,
 .select-input::placeholder {
   font-weight: 400;
-  color: #a3a3a3;
+  color: var(--grey-400);
+}
+
+.input:focus,
+.select-input:focus,
+.textarea:focus {
+  outline: none;
 }
 
 .icon {
@@ -58,28 +63,37 @@
   width: 20px;
   height: 20px;
   cursor: pointer;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.dropdownContainer {
+  position: absolute;
+  top: calc(100% + 8px);
+  width: 100%;
+  z-index: 1000;
+  background-color: #ffffff;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .textarea {
   width: 100%;
   height: 219px;
-  border: 1px solid #e5e5e5;
-  border-radius: 6px;
+  border: 1px solid var(--grey-200);
   padding: 16px 20px;
   margin-bottom: 30px;
   font-size: 16px;
-  color: #171717;
+  color: var(--grey-900);
 }
 
 .textarea::placeholder {
   font-weight: 400;
-  color: #a3a3a3;
+  color: var(--grey-400);
 }
 
 .submit-button {
   width: 100%;
   height: 48px;
-  background-color: #262626;
+  background-color: var(--grey-800);
   color: #ffffff;
   font-size: 16px;
   font-weight: 600;
@@ -93,6 +107,12 @@
   position: absolute;
   opacity: 0;
   pointer-events: none;
+}
+
+.error {
+  color: red;
+  font-size: 14px;
+  margin-top: 10px;
 }
 
 @media (max-width: 1199px) {
@@ -123,4 +143,3 @@
     padding: 14px;
   }
 }
-

--- a/src/variables/images.js
+++ b/src/variables/images.js
@@ -47,6 +47,9 @@ const assets = {
     thirdRank: '/assets/icons/ic_third_rank.svg',
     toggleDown: '/assets/icons/ic_toggle_down.svg',
     toggleUp: '/assets/icons/ic_toggle_up.svg',
+    up: '/assets/icons/ic_up.svg',
+    down: '/assets/icons/ic_down.svg',
+    calender: '/assets/icons/ic_calender.svg'
   },
   images: {
     black: '/assets/images/img_black.svg',


### PR DESCRIPTION
#### 추가사항

- [x] `DocTypeSelection` 컴포넌트 추가 및 신규 챌린지 신청 페이지에 연결
- [x] `FieldSelection` 컴포넌트 추가 및 신규 챌린지 신청 페이지에 연결
- [x] 신규 챌린지 신청 페이지 - 필드 및 문서 타입 매핑 추가
- [x] css 수정
- [x] raidus 수정
- [x] 색상 코드 이용으로 수정 (색상 코드에 없는 색 제외)
- [x] 최대 인원 입력 칸에 숫자만 허용되게 수정

#### 진행예정 (완료했다면 따로없거나 or 기능확장)

- [ ] 어드민 페이지

#### 테스트 완료 여부

- [x] 테스트 완료

#### 스크린샷
### 분야 - 선택 `전`
![image](https://github.com/user-attachments/assets/257a7750-ee28-4039-b1a1-07cd4d9203e6)

### 분야 - 선택 `후` ( 사용자가 선택한 `분야` 와 `문서 타입` 은 화면에 표시되는 값과 다르며, 백엔드에 전송되는 데이터는 매핑된 상수값을 사용하여 처리 )
![image](https://github.com/user-attachments/assets/028c984d-6a25-42bd-9ede-60fd0a10600c)

### 문서 타입 - 선택 `전`
![image](https://github.com/user-attachments/assets/b9a743bb-04cc-4515-9e8f-7d301d2d274b)

### 문서 타입 - 선택 `후` ( 사용자가 선택한 `분야` 와 `문서 타입` 은 화면에 표시되는 값과 다르며, 백엔드에 전송되는 데이터는 매핑된 상수값을 사용하여 처리 )
![image](https://github.com/user-attachments/assets/fd2c7217-8eb4-4d29-af79-482a43ab24b6)

### 신규 챌린지 신청 페이지
![image](https://github.com/user-attachments/assets/1276570e-4102-4f14-b029-3bc5b18c5893)

### 챌린지 수정 페이지
![image](https://github.com/user-attachments/assets/8c373def-f404-4255-8a49-88c246e83dba)

#### 코멘트
- 사용자가 'Next.js'를 선택하면 'NEXTJS'로 변환되어 전송
