### PR TITLE
[김민서] 어드민 전용 페이지  (챌린지 신청 관리 페이지, 챌린지 상세 페이지)

### DIFF
--- a/public/assets/icons/ic_line.svg
+++ b/public/assets/icons/ic_line.svg
@@ -1,0 +1,3 @@
+<svg width="3" height="15" viewBox="0 0 3 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.03125 0.09375V14.5938H0.875V0.09375H2.03125Z" fill="#E5E5E5"/>
+</svg>

--- a/src/components/application/AdminModal.jsx
+++ b/src/components/application/AdminModal.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import styles from "./AdminModal.module.css";
+import assets from "../../variables/images";
+
+export default function AdminModal({ type, onClose, onSubmit }) {
+  const [message, setMessage] = useState("");
+
+  const handleChange = (e) => {
+    setMessage(e.target.value);
+  };
+
+  const handleSubmit = () => {
+    const status = type === "reject" ? "REJECTED" : "DELETED";
+    const formData = {
+      status: status,
+      message: message,
+    };
+
+    onSubmit(formData);
+    onClose();
+  };
+
+  const handleModalClick = (e) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div className={styles.AdminModal}>
+      <div className={styles.modalContent} onClick={handleModalClick}>
+        <div className={styles.modalHeader}>
+          <span className={styles.title}>
+            {type === "reject" ? "거절 사유" : "삭제 사유"}
+          </span>
+          <img
+            src={assets.icons.out}
+            alt="닫기"
+            className={styles.closeButton}
+            onClick={onClose}
+          />
+        </div>
+        <div className={styles.modalBody}>
+          <label className={styles.label}>내용</label>
+          <textarea
+            className={styles.textarea}
+            placeholder={
+              type === "reject"
+                ? "거절 사유를 입력해주세요"
+                : "삭제 사유를 입력해주세요"
+            }
+            value={message}
+            onChange={handleChange}
+          ></textarea>
+        </div>
+        <button className={styles.submitButton} onClick={handleSubmit}>
+          전송
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/application/AdminModal.module.css
+++ b/src/components/application/AdminModal.module.css
@@ -1,0 +1,99 @@
+.AdminModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: #00000080;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modalContent {
+  background-color: #ffffff;
+  border-radius: 8px;
+  max-width: 496px;
+  width: 100%;
+  padding: 24px;
+  box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.title {
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 26px;
+  color: var(--grey-800);
+}
+
+.closeButton {
+  cursor: pointer;
+}
+
+.modalBody {
+  margin-bottom: 24px;
+}
+
+.label {
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 26px;
+  color: var(--grey-1717);
+  display: block;
+  margin-bottom: 8px;
+}
+
+.textarea {
+  width: 100%;
+  height: 219px;
+  border: 1px solid var(--grey-300);
+  border-radius: 6px;
+  padding: 16px;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 26px;
+  color: var(--grey-500);
+  resize: none;
+  box-sizing: border-box;
+}
+
+.submitButton {
+  width: 100%;
+  max-width: 448px;
+  height: 48px;
+  background-color: var(--grey-800);
+  border-radius: 12px;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 19.09px;
+  text-align: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@media (max-width: 744px) {
+  .modalContent {
+    max-width: 343px;
+  }
+
+  .textarea {
+    height: 219px;
+    resize: none;
+  }
+
+  .submitButton {
+    max-height: 40px;
+  }
+}
+

--- a/src/components/application/ApplicationDropdown.module.css
+++ b/src/components/application/ApplicationDropdown.module.css
@@ -1,7 +1,8 @@
 .ApplicationDropdown {
   position: relative;
-  max-width: 150px;
-  color: #737373;
+  max-width: 140px;
+  width: 100%;
+  color: var(--grey-500);
   width: 100%;
 }
 
@@ -11,7 +12,7 @@
   align-items: center;
   width: 100%;
   height: 40px;
-  border: 1px solid #d4d4d4;
+  border: 1px solid var(--grey-300);
   border-radius: 32px;
   background-color: #ffffff;
   padding: 8px 8px 8px 12px;
@@ -19,11 +20,10 @@
 }
 
 .selected-text {
-  font-family: Pretendard;
   font-weight: 400;
   font-size: 16px;
   line-height: 19.09px;
-  color: #a3a3a3;
+  color: var(--grey-300);
 }
 
 .icon {
@@ -39,11 +39,11 @@
   padding: 0;
   margin: 0;
   background-color: #ffffff;
-  border: 1px solid #d4d4d4;
+  border: 1px solid var(--grey-300);
   border-radius: 8px;
   z-index: 10;
   box-sizing: border-box;
-  color: #737373;
+  color: var(--grey-500);
 }
 
 .dropdown-item {
@@ -51,13 +51,12 @@
   justify-content: center;
   align-items: center;
   min-height: calc(280px / 7);
-  font-family: Pretendard;
   font-weight: 400;
   font-size: 16px;
   line-height: 19.09px;
-  color: #737373;
+  color: var(--grey-500);
   cursor: pointer;
-  border-bottom: 1px solid #d4d4d4;
+  border-bottom: 1px solid var(--grey-300);
   padding: 10px 0;
   width: 100%;
 }
@@ -74,12 +73,11 @@
   .dropdown-button {
     font-size: 14px;
     line-height: 19.09px;
+    min-width: 103px;
   }
 
   .dropdown-list {
-    max-width: 139px;
     min-height: 270px;
-    width: 100%;
   }
 
   .dropdown-item {
@@ -88,3 +86,4 @@
     min-height: calc(270px / 7);
   }
 }
+

--- a/src/components/application/ChallengeTable.jsx
+++ b/src/components/application/ChallengeTable.jsx
@@ -24,11 +24,11 @@ const getDocTypeLabel = (docType) => {
   return docType === "OFFICIAL" ? "공식문서" : "블로그";
 };
 
-const ChallengeTable = ({ data }) => {
+const ChallengeTable = ({ data, routerPath = "/me/application/" }) => {
   const router = useRouter();
 
   const handleRowClick = (id) => {
-    router.push(`/me/application/${id}`);
+    router.push(`${routerPath}${id}`);
   };
 
   return (

--- a/src/components/application/ChallengeTable.module.css
+++ b/src/components/application/ChallengeTable.module.css
@@ -9,19 +9,18 @@
   min-width: 696px;
 }
 
-/* 데스크탑 버전 */
 @media (min-width: 1200px) {
   .header,
   .row {
-    height: 36px;
+    height: 35px;
   }
 
   .header {
-    background-color: #262626;
+    background-color: var(--grey-800);
     color: #ffffff;
     font-weight: 500;
-    font-size: 13px;
-    line-height: 15.51px;
+    font-size: 12px;
+    line-height: 14px;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -46,11 +45,14 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-size: 12px;
+    line-height: 14px;
   }
 
   .title {
     flex: 3;
     justify-content: start;
+    color: inherit;
   }
 
   .field,
@@ -60,38 +62,41 @@
 
   .row {
     background-color: #ffffff;
-    color: #737373;
-    border-bottom: 1px solid #d4d4d4;
-    font-family: Pretendard;
+    color: var(--grey-500);
+    border-bottom: 1px solid var(--grey-300);
     font-weight: 400;
-    font-size: 13px;
-    line-height: 15.51px;
+    font-size: 12px;
+    line-height: 14px;
     display: flex;
     justify-content: space-between;
     align-items: center;
   }
 
+  .row .title {
+    font-weight: 500;
+    color: var(--grey-700);
+  }
+
   .row:last-child {
-    border-bottom: 1px solid #d4d4d4;
+    border-bottom: 1px solid var(--grey-300);
   }
 }
 
-/* 태블릿 및 모바일 버전 */
+/* 태블릿  버전 */
 @media (max-width: 1199px) {
   .header,
   .row {
-    height: 36px;
+    height: 35px;
     box-sizing: border-box;
     width: 100%;
   }
 
   .header {
-    background-color: #262626;
+    background-color: var(--grey-800);
     color: #ffffff;
-    font-family: Pretendard;
     font-weight: 500;
-    font-size: 13px;
-    line-height: 15.51px;
+    font-size: 12px;
+    line-height: 14px;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -106,7 +111,7 @@
   .applicationDate,
   .deadline,
   .status {
-    padding: 15px 12px;
+    padding: 14px 11px;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -115,11 +120,14 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-size: 12px;
+    line-height: 14px;
   }
 
   .title {
     flex: 3;
     justify-content: start;
+    color: inherit;
   }
 
   .field,
@@ -129,12 +137,11 @@
 
   .row {
     background-color: #ffffff;
-    color: #737373;
-    border-bottom: 1px solid #d4d4d4;
-    font-family: Pretendard;
+    color: var(--grey-500);
+    border-bottom: 1px solid var(--grey-300);
     font-weight: 400;
-    font-size: 13px;
-    line-height: 15.51px;
+    font-size: 12px;
+    line-height: 14px;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -142,11 +149,11 @@
 
   .row .title {
     font-weight: 500;
-    color: #404040;
+    color: var(--grey-700);
   }
 
   .row:last-child {
-    border-bottom: 1px solid #d4d4d4;
+    border-bottom: 1px solid var(--grey-300);
   }
 }
 
@@ -165,20 +172,19 @@
   }
 
   .header {
-    background-color: #262626;
+    background-color: var(--grey-800);
     color: #ffffff;
-    font-family: Pretendard;
     font-weight: 500;
-    font-size: 12px;
+    line-height: 13px;
     border-radius: 8px;
   }
 
   .row {
     background-color: #ffffff;
-    color: #737373;
-    font-family: Pretendard;
+    color: var(--grey-500);
     font-weight: 400;
-    font-size: 12px;
+    font-size: 11px;
+    line-height: 13px;
   }
 }
 
@@ -187,7 +193,7 @@
   max-height: 24px;
   border-radius: 4px;
   padding: 4px 8px;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   display: flex;
   justify-content: center;
@@ -210,10 +216,11 @@
 }
 
 .deleted {
-  background-color: #e5e5e5;
-  color: #737373;
+  background-color: var(--grey-200);
+  color: var(--grey-500);
 }
 
 .deletedRow {
   background-color: #f5f5f5 !important;
 }
+

--- a/src/components/application/ReasonBox.jsx
+++ b/src/components/application/ReasonBox.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styles from './ReasonBox.module.css';
+import assets from '../../variables/images';
+
+const ReasonBox = ({ type, message, nickname, updatedAt }) => {
+    const date = new Date(updatedAt);
+    const hours = date.getHours();
+    const formattedDate = `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ${hours >= 12 ? '오후' : '오전'} ${hours % 12 || 12}시 ${date.getMinutes()}분`;
+
+    return (
+        <div className={styles.ReasonBox}>
+            <div className={styles['reason-header']}>
+                <span className={styles['reason-title']}>
+                    {type === 'reject' ? '신청 거절 사유' : '신청 삭제 사유'}
+                </span>
+            </div>
+
+            <div className={styles['reason-content']}>
+                <p className={styles['reason-text']}>{message}</p>
+            </div>
+
+            <div className={styles['reason-footer']}>
+                <span className={styles['user-info']}>{nickname}</span>
+                <img src={assets.icons.line} alt="구분선" className={styles['line-icon']} />
+                <span className={styles.timestamp}>{formattedDate}</span>
+            </div>
+        </div>
+    );
+};
+
+export default ReasonBox;
+

--- a/src/components/application/ReasonBox.module.css
+++ b/src/components/application/ReasonBox.module.css
@@ -1,0 +1,74 @@
+.ReasonBox {
+  width: 100%;
+  border: 1px solid var(--grey-200);
+  border-radius: 16px;
+  padding: 16px;
+  margin-top: 20px;
+  background-color: var(--grey-50);
+}
+
+.reason-header {
+  text-align: center;
+}
+
+.reason-title {
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 16.71px;
+  color: var(--grey-800);
+}
+
+.reason-content {
+  margin: 16px 0;
+  text-align: center;
+}
+
+.reason-text {
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 19.9px;
+  color: var(--grey-700);
+}
+
+.reason-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.user-info {
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16.71px;
+  color: var(--grey-700);
+}
+
+.line-icon {
+  margin: 0 8px;
+}
+
+.timestamp {
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16.71px;
+  color: var(--grey-500);
+}
+
+@media (min-width: 1200px) {
+  .ReasonBox {
+    min-height: 117px;
+  }
+}
+
+@media (min-width: 745px) and (max-width: 1199px) {
+  .ReasonBox {
+    max-height: 136px;
+  }
+}
+
+@media (max-width: 744px) {
+  .ReasonBox {
+    max-height: 149px;
+  }
+}
+

--- a/src/components/challenge/ChallengeSearchBar.module.css
+++ b/src/components/challenge/ChallengeSearchBar.module.css
@@ -21,7 +21,7 @@
   background-color: transparent;
   font-weight: 400;
   color: var(--grey-400);
-  padding-left: 8px;
+  padding-left: 0px;
   outline: none;
 }
 
@@ -31,7 +31,8 @@
 
 @media (min-width: 1200px) {
   .ChallengeSearchBar {
-    max-width: 744px;
+    max-width: 844px;
+    width: 100%;
   }
 
   .input {
@@ -42,7 +43,7 @@
 
 @media (min-width: 744px) and (max-width: 1199px) {
   .ChallengeSearchBar {
-    max-width: 545px;
+    min-width: 544px;
   }
 
   .input {
@@ -53,7 +54,12 @@
 
 @media (max-width: 743px) {
   .ChallengeSearchBar {
-    max-width: 100%;
+    min-width: 228px;
+    padding: 0 8px;
+  }
+
+  .icon {
+    margin-right: 3px;
   }
 
   .input {
@@ -61,3 +67,4 @@
     line-height: 16.71px;
   }
 }
+

--- a/src/components/challenge/SearchBarWithDropdown.module.css
+++ b/src/components/challenge/SearchBarWithDropdown.module.css
@@ -3,16 +3,15 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  max-width: 996px;
   margin: 0;
-  width: 100%;
 }
 
 .SearchBarWithDropdown > * {
-  flex-shrink: 0;
+  flex-shrink: 1;
   margin-right: 5px;
 }
 
 .SearchBarWithDropdown > *:last-child {
   margin-right: 0;
 }
+

--- a/src/pages/admin/application/[id].jsx
+++ b/src/pages/admin/application/[id].jsx
@@ -1,18 +1,189 @@
-import Head from 'next/head';
+import { useRouter } from "next/router";
+import Head from "next/head";
+import { useEffect, useState } from "react";
+import ChallengeStatusBadge from "../../../components/application/ChallengeStatusBadge";
+import DocTypeChip from "../../../components/common/DocTypeChip";
+import InfoContainer from "../../../components/challenge/InfoContainer";
+import KebabMenu from "../../../components/common/KebabMenu";
+import AdminModal from "../../../components/application/AdminModal";
+import ReasonBox from "../../../components/application/ReasonBox";
+import { getChallenge, updateChallenge } from "../../../service/api/challenge";
+import Loader from "../../../components/common/Loader";
+import styles from "../../../styles/pages/application/AdminApplicationDetailPage.module.css";
+import assets from "@/variables/images";
 
 export default function AdminApplicationDetailPage() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const [challenge, setChallenge] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalType, setModalType] = useState("");
+  const [reasonData, setReasonData] = useState(null);
+
+  useEffect(() => {
+    if (id) {
+      const fetchChallenge = async () => {
+        try {
+          setLoading(true);
+          const data = await getChallenge(id);
+          setChallenge(data);
+
+          if (data.status === "REJECTED" || data.status === "DELETED") {
+            setReasonData({
+              type: data.status === "REJECTED" ? "reject" : "delete",
+              message: data.message,
+              nickname: "독스루 운영진",
+              updatedAt: data.updatedAt,
+            });
+          }
+        } catch (error) {
+          setError("챌린지를 불러오는데 실패했습니다.");
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      fetchChallenge();
+    }
+  }, [id]);
+
+  const handleDelete = () => {
+    setModalType("delete");
+    setIsModalOpen(true);
+  };
+
+  const handleReject = () => {
+    setModalType("reject");
+    setIsModalOpen(true);
+  };
+
+  const handleApprove = async () => {
+    try {
+      await updateChallenge(id, { status: "ACCEPTED" });
+      setChallenge({ ...challenge, status: "ACCEPTED" });
+      alert("챌린지가 승인되었습니다.");
+    } catch (error) {
+      alert("승인 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleEdit = () => {
+    router.push(`/application/${id}`);
+  };
+
+  const handleModalSubmit = async (formData) => {
+    try {
+      await updateChallenge(id, { ...formData });
+      setChallenge({
+        ...challenge,
+        status: formData.status,
+        message: formData.message,
+      });
+      setReasonData({
+        type: formData.status === "REJECTED" ? "reject" : "delete",
+        message: formData.message,
+        nickname: "독스루 운영진",
+        updatedAt: new Date().toISOString(),
+      });
+      setIsModalOpen(false);
+    } catch (error) {
+      alert("처리 중 오류가 발생했습니다.");
+    }
+  };
+
+  if (loading) {
+    return <Loader msg="챌린지를 불러오는 중" />;
+  }
+
+  if (error) {
+    return <div>{error}</div>;
+  }
+
+  if (!challenge) {
+    return <div>해당 챌린지를 찾을 수 없습니다.</div>;
+  }
+
   return (
     <>
       <Head>
         <title>신청 관리 디테일 페이지</title>
         <meta
           name="description"
-          content="관리자에게 보여지는 신청 관리 디테일 페이지입니다."
+          content={`관리자가 보는 신청 관리 상세 페이지입니다.`}
         />
       </Head>
-      <div>
-        <h1>신청 관리 디테일 페이지 내용</h1>
+      <div className={styles.pageContainer}>
+        <div className={styles.idNumber}>No.{id}</div>
+        <ChallengeStatusBadge status={challenge.status} />
+
+        {reasonData && (
+          <>
+            <ReasonBox {...reasonData} />
+            <div className={styles.reasonBoxBorder} />
+          </>
+        )}
+
+        <div className={styles.titleContainer}>
+          <h1 className={styles.title}>{challenge.title}</h1>
+          <KebabMenu onEdit={handleEdit} onDelete={handleDelete} />
+        </div>
+
+        <div className={styles.docTypeContainer}>
+          <DocTypeChip field={challenge.field} docType={challenge.docType} />
+        </div>
+
+        <p className={styles.description}>{challenge.description}</p>
+
+        <InfoContainer
+          applicationDate={challenge.createdAt}
+          deadline={challenge.deadline}
+          maxParticipants={challenge.maxParticipants}
+        />
+
+        <div className={styles.bottomBorder} />
+
+        <a href={challenge.docUrl} className={styles.originalLink}>
+          원문 링크
+        </a>
+
+        <div className={styles.previewContainer}>
+          <iframe
+            src={challenge.docUrl}
+            className={styles.iframePreview}
+            title="Document Preview"
+          ></iframe>
+          <button
+            className={styles.previewButton}
+            onClick={() => window.open(challenge.docUrl, '_blank')}
+          >
+            링크 열기
+            <img src={assets.icons.diagonal} alt="링크 열기" />
+          </button>
+        </div>
+
+        {challenge.status === "WAITING" && (
+          <div className={styles.buttonContainer}>
+            <button className={styles.rejectButton} onClick={handleReject}>
+              거절하기
+            </button>
+            <button className={styles.approveButton} onClick={handleApprove}>
+              승인하기
+            </button>
+          </div>
+        )}
       </div>
+
+      {isModalOpen && (
+        <AdminModal
+          type={modalType}
+          onClose={() => setIsModalOpen(false)}
+          onSubmit={handleModalSubmit}
+        />
+      )}
     </>
   );
 }
+

--- a/src/pages/admin/application/index.jsx
+++ b/src/pages/admin/application/index.jsx
@@ -1,14 +1,108 @@
-import Head from 'next/head';
+import { useState, useEffect } from "react";
+import Head from "next/head";
+import SearchBarWithDropdown from "../../../components/challenge/SearchBarWithDropdown";
+import ChallengeTable from "../../../components/application/ChallengeTable";
+import Pagination from "../../../components/application/Pagination";
+import { getAllChallengeApplications } from "../../../service/api/challenge";
+import Loader from "../../../components/common/Loader";
+import styles from "../../../styles/pages/application/AdminApplicationPage.module.css";
 
 export default function AdminApplicationPage() {
+  const [selectedOption, setSelectedOption] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [applications, setApplications] = useState([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const itemsPerPage = 10;
+
+  const fetchApplications = async () => {
+    setLoading(true);
+    try {
+      let status;
+      if (selectedOption === "승인 대기") status = "WAITING";
+      else if (selectedOption === "신청 승인") status = "ACCEPTED";
+      else if (selectedOption === "신청 거절") status = "REJECTED";
+
+      const response = await getAllChallengeApplications({
+        status,
+        keyword: searchTerm,
+        page: currentPage,
+        limit: itemsPerPage,
+      });
+
+      if (response && response.challenge) {
+        setApplications(response.challenge);
+        setTotalPages(response.totalPages || 1);
+      } else {
+        setApplications([]);
+        setTotalPages(1);
+      }
+    } catch (error) {
+      if (error.response) {
+        console.error("서버 문제: 응답을 받았지만 에러가 발생", error.response);
+      } else if (error.request) {
+        console.error("요청을 보냈지만 서버 응답이 없습니다.", error.request);
+      } else {
+        console.error("API 요청 문제입니다.", error.message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchApplications();
+  }, [selectedOption, searchTerm, currentPage]);
+
+  const handleOptionChange = (option) => {
+    setSelectedOption(option);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+  };
+
   return (
     <>
       <Head>
-        <title>신청 관리 페이지</title>
-        <meta name="description" content="관리자에게 보여지는 신청 관리 페이지입니다." />
+        <title>챌린지 신청 관리</title>
+        <meta
+          name="description"
+          content="관리자가 챌린지 신청을 관리하는 페이지입니다."
+        />
       </Head>
-      <div>
-      <h1>신청 관리 페이지 내용</h1>
+      <div className={styles.pageContainer}>
+        <h1 className={styles.pageTitle}>챌린지 신청 관리</h1>
+        <div className={styles.applicationSearchDropdownContainer}>
+          <SearchBarWithDropdown
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+            onOptionChange={handleOptionChange}
+          />
+        </div>
+        <div className={styles.challengeTableWrapper}>
+          {loading ? (
+            <Loader msg="챌린지를 불러오는 중" />
+          ) : applications && applications.length > 0 ? (
+            <ChallengeTable
+              data={applications}
+              routerPath="/admin/application/"
+            />
+          ) : (
+            <div className={styles.noChallengesMessage}>
+              아직 챌린지가 없어요.
+            </div>
+          )}
+        </div>
+        <div className={styles.paginationWrapper}>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
       </div>
     </>
   );

--- a/src/pages/application/index.jsx
+++ b/src/pages/application/index.jsx
@@ -68,7 +68,7 @@ const CreateApplicationPage = () => {
     setSelectedDate(date);
     setFormData((prevData) => ({
       ...prevData,
-      deadline: new Date(date).toISOString(), // ISO 형식으로 변환하여 저장
+      deadline: new Date(date).toISOString(),
     }));
   };
 
@@ -297,3 +297,4 @@ const CreateApplicationPage = () => {
 };
 
 export default CreateApplicationPage;
+

--- a/src/pages/me/application/[id].jsx
+++ b/src/pages/me/application/[id].jsx
@@ -5,9 +5,11 @@ import ChallengeStatusBadge from "../../../components/application/ChallengeStatu
 import DocTypeChip from "../../../components/common/DocTypeChip";
 import InfoContainer from "../../../components/challenge/InfoContainer";
 import CancelMenu from "../../../components/common/CancelMenu";
+import ReasonBox from "../../../components/application/ReasonBox";
 import { getChallenge, deleteChallenges } from "../../../service/api/challenge";
 import Loader from "../../../components/common/Loader";
 import styles from "../../../styles/pages/application/MyApplicationDetailPage.module.css";
+import assets from "@/variables/images";
 
 export default function MyApplicationDetailPage() {
   const router = useRouter();
@@ -69,6 +71,19 @@ export default function MyApplicationDetailPage() {
       <div className={styles.pageContainer}>
         <ChallengeStatusBadge status={challenge.status} />
 
+        {(challenge.status === "REJECTED" ||
+          challenge.status === "DELETED") && (
+          <>
+            <ReasonBox
+              type={challenge.status === "REJECTED" ? "거절" : "삭제"}
+              message={challenge.message}
+              nickname="독스루 운영진"
+              updatedAt={challenge.updatedAt}
+            />
+            <div className={styles.bottomBorder} />
+          </>
+        )}
+
         <div className={styles.titleContainer}>
           <h1 className={styles.title}>{challenge.title}</h1>
           <CancelMenu onDelete={handleDelete} />
@@ -100,10 +115,10 @@ export default function MyApplicationDetailPage() {
           ></iframe>
           <button
             className={styles.previewButton}
-            onClick={() => (window.location.href = challenge.docUrl)}
+            onClick={() => window.open(challenge.docUrl, '_blank')}
           >
             링크 열기
-            <img src="/assets/icons/ic_diagonal.svg" alt="링크 열기" />
+            <img src={assets.icons.diagonal} alt="링크 열기" />
           </button>
         </div>
       </div>

--- a/src/pages/work/[id]/edit.jsx
+++ b/src/pages/work/[id]/edit.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const EditPage = () => {
+  return (
+    <div>
+      <h1>Edit Page</h1>
+      {/* 페이지 내용 */}
+    </div>
+  );
+};
+
+export default EditPage;

--- a/src/service/api/axios.js
+++ b/src/service/api/axios.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import CAN_USE_DOM from '@/utils/canUseDom';
 
 const API_URL =
-  process.env.NEXT_PUBLIC_DEV_API_URL || process.env.NEXT_PUBLIC_API_URL;
+  process.env.NEXT_PUBLIC_API_URL;
 
 const TokenService = {
   get: () => (CAN_USE_DOM ? localStorage.getItem('accessToken') : null),

--- a/src/service/api/challenge.js
+++ b/src/service/api/challenge.js
@@ -70,3 +70,64 @@ export async function createChallengeApplication(data) {
   return res.data;
 }
 
+
+/** GET - 챌린지 전체 조회 (챌린지 신청 관리) - 어드민 전용 */
+export async function getAllChallengeApplications({
+  page = 1,
+  limit = 10,
+  sortBy = 'createdAt',
+  sortOrder = 'desc',
+  keyword = '',
+  status = '',
+} = {}) {
+  try {
+    const params = {
+      page,
+      limit,
+      sortBy: status ? 'status' : sortBy, // status가 있을 경우 sortBy를 'status'로 설정
+      sortOrder: status || sortOrder, // status가 있을 경우 sortOrder를 상태 값으로 설정
+      ...(keyword && { keyword }), // 검색어가 있을 경우에만 추가
+    };
+
+    // API 호출
+    const response = await axios.get(`${PATH}/application`, { params });
+    return response.data;
+  } catch (error) {
+    throw new Error(error.response?.data?.message || '챌린지 목록 조회 실패');
+  }
+}
+
+/** PATCH - 어드민 챌린지 수정 (챌린지 상태 변경 포함) */
+export async function updateChallengeAdmin({
+  challengeId,
+  title,
+  field,
+  docType,
+  description,
+  docUrl,
+  deadline,
+  progress,
+  maxParticipants,
+  status,
+  message,
+}) {
+  try {
+    const body = {
+      ...(title && { title }),
+      ...(field && { field }),
+      ...(docType && { docType }),
+      ...(description && { description }),
+      ...(docUrl && { docUrl }),
+      ...(deadline && { deadline }),
+      ...(progress !== undefined && { progress }), // boolean 값 체크
+      ...(maxParticipants && { maxParticipants }),
+      ...(status && { status }),
+      ...(message && { message }),
+    };
+
+    const response = await axios.patch(`${PATH}/${challengeId}`, body);
+    return response.data; // 수정된 챌린지 정보 반환
+  } catch (error) {
+    throw new Error(error.response?.data?.message || '챌린지 수정 실패');
+  }
+}

--- a/src/styles/pages/application/AdminApplicationDetailPage.module.css
+++ b/src/styles/pages/application/AdminApplicationDetailPage.module.css
@@ -7,7 +7,7 @@
 .idNumber {
   font-size: 20px;
   font-weight: 500;
-  color: var(--grey-200);
+  color: var(--grey-700);
   margin-bottom: 30px;
 }
 

--- a/src/styles/pages/application/AdminApplicationDetailPage.module.css
+++ b/src/styles/pages/application/AdminApplicationDetailPage.module.css
@@ -1,7 +1,14 @@
 .pageContainer {
   width: 100%;
   box-sizing: border-box;
-  margin-top: 15px;
+  margin-top: 30px;
+}
+
+.idNumber {
+  font-size: 20px;
+  font-weight: 500;
+  color: var(--grey-200);
+  margin-bottom: 30px;
 }
 
 .titleContainer {
@@ -9,7 +16,6 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 20px;
-  margin-top: 30px;
 }
 
 .title {
@@ -29,7 +35,7 @@
   font-weight: 500;
   font-size: 16px;
   line-height: 20.8px;
-  color: var(--grey-700);
+  color: var(--grey-800);
   max-width: 100%;
   margin-bottom: 30px;
   word-wrap: break-word;
@@ -38,7 +44,6 @@
 .bottomBorder {
   border-bottom: 1px solid var(--grey-200);
   margin-bottom: 25px;
-  margin-top: 20px;
 }
 
 .originalLink {
@@ -46,11 +51,10 @@
   font-weight: 600;
   font-size: 18px;
   line-height: 21.48px;
-  color: #262626;
+  color: var(--grey-800);
   margin-top: 30px;
 }
 
-/* 미리보기 */
 .previewContainer {
   position: relative;
   margin-top: 20px;
@@ -147,4 +151,51 @@
   }
 }
 
+.titleContainer {
+  margin-top: 20px;
+}
+
+.reasonBoxBorder {
+  border-bottom: 1px solid var(--grey-200);
+  margin: 20px 0;
+}
+
+.buttonContainer {
+  margin-top: 30px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 20px;
+  border-top: 1px solid var(--grey-200);
+  padding-top: 30px;
+}
+
+.approveButton {
+  width: 153px;
+  height: 48px;
+  background-color: var(--grey-800);
+  border-radius: 12px;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 19.09px;
+}
+
+.rejectButton {
+  width: 153px;
+  height: 48px;
+  background-color: #ffe7e7;
+  border-radius: 12px;
+  color: #f24744;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 19.09px;
+}
+
+@media (max-width: 743px) {
+  .approveButton,
+  .rejectButton {
+    width: 166px;
+    height: 40px;
+  }
+}
 

--- a/src/styles/pages/application/AdminApplicationPage.module.css
+++ b/src/styles/pages/application/AdminApplicationPage.module.css
@@ -4,14 +4,14 @@
 }
 
 .applicationSearchDropdownContainer {
+  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 100%;
   margin-bottom: 20px;
   margin-top: 20px;
   box-sizing: border-box;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
 .applicationSearchDropdownContainer > * {
@@ -31,6 +31,7 @@
 }
 
 .noChallengesMessage {
+  font-family: Pretendard;
   font-weight: 400;
   font-size: 16px;
   line-height: 19.09px;
@@ -47,8 +48,9 @@
 }
 
 /* 모바일 버전 */
-@media (max-width: 743px) {
+@media (max-width: 743px) and (min-width: 375px) {
   .applicationSearchDropdownContainer {
+    width: 100%;
     flex-direction: column;
     align-items: stretch;
   }

--- a/src/styles/pages/application/CreateApplicationPage.module.css
+++ b/src/styles/pages/application/CreateApplicationPage.module.css
@@ -118,11 +118,12 @@
   width: 100%;
   height: 219px;
   border: 1px solid var(--grey-200);
-
   padding: 16px 20px;
   margin-bottom: 30px;
   font-size: 16px;
   color: var(--grey-900);
+  resize: none;
+  box-sizing: border-box;
 }
 
 .textarea::placeholder {

--- a/src/styles/pages/application/EditApplicationPage.module.css
+++ b/src/styles/pages/application/EditApplicationPage.module.css
@@ -83,6 +83,8 @@
   margin-bottom: 30px;
   font-size: 16px;
   color: var(--grey-900);
+  resize: none;
+  box-sizing: border-box;
 }
 
 .textarea::placeholder {
@@ -143,3 +145,4 @@
     padding: 14px;
   }
 }
+

--- a/src/variables/images.js
+++ b/src/variables/images.js
@@ -56,6 +56,7 @@ const assets = {
     toggleDown: '/assets/icons/ic_toggle_down.svg',
     toggleUp: '/assets/icons/ic_toggle_up.svg',
     up: '/assets/icons/ic_up.svg',
+    line: '/assets/icons/ic_line.svg'
   },
   images: {
     black: '/assets/images/img_black.svg',


### PR DESCRIPTION
#### 추가사항
- [x] 어드민 전용 페이지
- [x] 챌린지 신청 관리 페이지 `/admin/application`
- [x] 챌린지 상세 페이지 `/admin/application/id`
- [x] 신청 삭제 / 신청 거절 모달 `AdminModal` 
- [x] 신청 삭제, 신청 거절 사유 안내 메세지 `ReasonBox`
- [x] 승인 대기 중 상태일 때만 거절하기, 승인하기 버튼 표시
- [x] 링크 열기 클릭 시 새 창으로 링크 열기
- [x] 어드민 전용 - 챌린지 수정페이지 API 연동
- [x] `ChallengeTable` 컴포넌트 padding 미세 조정

#### 진행예정 (완료했다면 따로없거나 or 기능확장)
- [ ] `BestRecWork` 컴포넌트를 챌린지 상세 페이지 하단 부에 추가

#### 테스트 완료 여부
- [x] 테스트 완료

#### 스크린샷
### 챌린지 신청 관리 페이지 ( 반응형까지 구현 완료 )
![image](https://github.com/user-attachments/assets/bfd94c77-a347-4986-a593-1ab26caebe45)

- 검색 기능
![image](https://github.com/user-attachments/assets/632efc3f-b01a-4c1a-be1e-259ee9e3b74e)

- 승인 대기 
![image](https://github.com/user-attachments/assets/4623871e-cae6-469e-b097-ccae51ab1367)

- 신청 승인
![image](https://github.com/user-attachments/assets/f52b74d6-0670-4748-8faa-34927ad3f44e)

- 신청 거절
![image](https://github.com/user-attachments/assets/a39d83df-94f1-4a20-8726-2725a53ff484)

### 챌린지 상세 페이지 
- 승인 대기 상태일 때만 `거절하기`, `승인하기` 버튼이 표시
![image](https://github.com/user-attachments/assets/5c648744-71ac-427f-ae02-fb81b27ce87f)

- `수정하기`  버튼 클릭 시 - 어드민 전용 챌린지 수정하기 페이지로 이동
![image](https://github.com/user-attachments/assets/288a3ec8-f465-4295-a8ce-27c5394739a7)

- 수정 완료 시 어드민 전용 챌린지의 해당 챌린지 상세 페이지로 이동
![image](https://github.com/user-attachments/assets/c75a3f25-db93-43cf-b084-520ab6bef989)

### 어드민의 신청 삭제 사유 입력 - 전송 전
![image](https://github.com/user-attachments/assets/c0ab818e-6b08-471e-98e7-121deb046d60)

### 어드민의 신청 삭제 사유가 반영된 해당 챌린지 상세 페이지 ( 일반 유저도 공통 )
![image](https://github.com/user-attachments/assets/db3604ee-9f97-40a9-9e6e-4b39db1bd577)

### 어드민의 신청 거절 사유 입력 - 전송 전
![image](https://github.com/user-attachments/assets/b3a5fdf1-91c9-42c8-847f-16cf3c86b480)

### 어드민의 신청 거절 사유가 반영된 해당 챌린지 상세 페이지 ( 일반 유저도 공통)
![image](https://github.com/user-attachments/assets/2cc15dee-f1d0-4081-828b-816378635893)


#### 코멘트
- 여기까지해서 재배포 하겠습니다.